### PR TITLE
Gitの設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.Ds_Store


### PR DESCRIPTION
#What
.gitignoreに.Ds_Storeを記述

#Why
.Ds_StoreをGitで管理しないため